### PR TITLE
Introduction of scala-js plugin support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import sbt.Keys.target
 // Resolvers
 resolvers += Resolver.sonatypeRepo("snapshots")
 resolvers += Resolver.typesafeRepo("releases")
@@ -97,15 +98,20 @@ lazy val scafi = project.in(file(".")).
 
 lazy val commons = project.
   settings(commonSettings: _*).
-  settings(name := "scafi-commons")
+  enablePlugins(ScalaJSPlugin).
+  settings(
+    name := "scafi-commons"
+  )
 
 lazy val core = project.
   dependsOn(commons).
+  enablePlugins(ScalaJSPlugin).
   settings(commonSettings: _*).
   settings(
     name := "scafi-core",
     libraryDependencies += scalatest
   )
+
 
 lazy val `stdlib-ext` = project.
   dependsOn(core).
@@ -114,12 +120,12 @@ lazy val `stdlib-ext` = project.
     name := "scafi-lib-ext",
     libraryDependencies ++= Seq(scalatest, shapeless)
   )
-
 lazy val simulator = project.
   dependsOn(core).
   settings(commonSettings: _*).
+  enablePlugins(ScalaJSPlugin).
   settings(
-    name := "scafi-simulator"
+    name := "scafi-simulator",
   )
 
 lazy val `simulator-gui` = project.
@@ -190,4 +196,15 @@ lazy val `demos-new` = project.
   settings(
     name := "scafi-demos-new",
     compileScalastyle := ()
+  )
+
+//SCAFI JS
+lazy val scafijs = project.
+  settings(commonSettings: _*).
+  dependsOn(commons, core, simulator).
+  enablePlugins(ScalaJSPlugin).
+  settings(
+    name := "scafijs" ,
+    scalaJSUseMainModuleInitializer := true,
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.0.0"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,3 +22,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
+

--- a/scafijs/src/main/resources/index.html
+++ b/scafijs/src/main/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Scafi</title>
+  </head>
+  <body>
+    <h1> Apri la console, il simulatore è in esecuzione in background</h1>
+    <!-- Include Scala.js compiled code -->
+    <script type="text/javascript" src="../scafijs-fastopt.js"></script>
+  </body>
+</html>

--- a/scafijs/src/main/scala/it/unibo/scafijs/Index.scala
+++ b/scafijs/src/main/scala/it/unibo/scafijs/Index.scala
@@ -1,0 +1,31 @@
+package it.unibo.scafijs
+
+import it.unibo.scafi.incarnations.BasicSimulationIncarnation
+import it.unibo.scafi.incarnations.BasicSimulationIncarnation._
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * from the main body, scala js produce a javascript file.
+  * it is an example of a ScaFi simulation transcompilated in javascript.
+  */
+object Index {
+  import org.scalajs.dom._
+
+  class FooProgram extends AggregateProgram {
+    override def main(): Any = rep(Math.random())(x => x)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val nodes = ArrayBuffer((0 to 100):_*)
+    val net = BasicSimulationIncarnation.simulatorFactory.basicSimulator(
+      nodes
+    )
+    val elem : CONTEXT => EXPORT = new FooProgram()
+    import scalajs.js.timers._
+
+    setInterval(1000) {
+      println(net.exec(elem))
+    }
+  }
+}


### PR DESCRIPTION
This work allow to trascompile ScaFi simulation and interpreter in javascript.
In https://scafijs.web.app/ there is the result of trascompilation of the file it.unibo.scafijs.Index stored in the project _scafijs_.

To trascompile in javascript follow this steps:

- open an sbt console
- type **project scafijs**
- type **fastOptJS**

To see the result, open scafijs/target/scafi-2.12/classes/index.html

This work will be considered with a view to future project.